### PR TITLE
Add path to SignIn & SignUp components

### DIFF
--- a/app/routes/sign-in.$/route.tsx
+++ b/app/routes/sign-in.$/route.tsx
@@ -4,7 +4,7 @@ export default function SignInPage() {
   return (
     <div>
       <h1>Sign In route</h1>
-      <SignIn />
+      <SignIn path="/sign-in" />
     </div>
   );
 }

--- a/app/routes/sign-up.$/route.tsx
+++ b/app/routes/sign-up.$/route.tsx
@@ -4,7 +4,7 @@ export default function SignUpPage() {
   return (
     <div>
       <h1>Sign Up route</h1>
-      <SignUp />
+      <SignUp path="/sign-up" />
     </div>
   );
 }


### PR DESCRIPTION
When you visit /sign-in & /sign-up an error is thrown because SignIn & SignUp expect a path prop when using path-based routing.

This PR adds the path to the components.